### PR TITLE
Add weekday

### DIFF
--- a/script.js
+++ b/script.js
@@ -12,10 +12,13 @@ function findDate() {
   const targetDate = new Date(startDate);
   targetDate.setDate(startDate.getDate() + dayNumber - 1); 
 
-  const options = { year: "numeric", month: "long", day: "numeric", weekday: "long" };
+  const options = { year: "numeric", month: "long", day: "numeric" };
   const formattedDate = targetDate.toLocaleDateString("en-US", options);
 
-  result.textContent = `Today is ${formattedDate} in Blue Prince.`;
+  const daysOfWeek = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+  const currentDayOfTheWeek = daysOfWeek[(targetDate.getDay() - 1) % 7];
+
+  result.textContent = `Today is ${currentDayOfTheWeek}, ${formattedDate} in Blue Prince.`;
 }
 
 function resetForm() {

--- a/script.js
+++ b/script.js
@@ -12,7 +12,7 @@ function findDate() {
   const targetDate = new Date(startDate);
   targetDate.setDate(startDate.getDate() + dayNumber - 1); 
 
-  const options = { year: "numeric", month: "long", day: "numeric" };
+  const options = { year: "numeric", month: "long", day: "numeric", weekday: "long" };
   const formattedDate = targetDate.toLocaleDateString("en-US", options);
 
   result.textContent = `Today is ${formattedDate} in Blue Prince.`;


### PR DESCRIPTION
Hello

The day of the week in Blue Prince is displayed in multiple places.

There are also clues that some things, (the heist, the closed exhibit) are affected by the day of the week.

The code looks off because the days in blue prince are offset by -1 compared to real life. Nov 26 1993 was a friday. In blue prince, it's a thursday. I initially just added `weekday: "long"` to the formatting but realized with the vault that it doesn't give the right date

![blue-prince-vault-date-check](https://github.com/user-attachments/assets/14e70753-8792-4f8a-9103-c09f0ecf83a8)

Anyway the reason to add the day of the week to 1) Match the way the game gives it and 2) Give the information to those who may want it


